### PR TITLE
from async-stripe into main

### DIFF
--- a/.sqlx/query-1ef6868d5346bbce08fe83a1f57e5c04edc703f8b58499f7d79e973d003c4722.json
+++ b/.sqlx/query-1ef6868d5346bbce08fe83a1f57e5c04edc703f8b58499f7d79e973d003c4722.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE transactions\n            SET payment_intent_id = $1, status = $2, updated_at = $3\n            WHERE id = $4\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Varchar",
+        "Timestamp",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1ef6868d5346bbce08fe83a1f57e5c04edc703f8b58499f7d79e973d003c4722"
+}

--- a/.sqlx/query-9bf13c4cb1e36f4fef5f53edd37b268c18bbc6acd762647221012005746f370a.json
+++ b/.sqlx/query-9bf13c4cb1e36f4fef5f53edd37b268c18bbc6acd762647221012005746f370a.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, payment_intent_id, session_id, amount, currency, status, created_at, updated_at\n            FROM transactions\n            WHERE session_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "payment_intent_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "session_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "amount",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "currency",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamp"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "9bf13c4cb1e36f4fef5f53edd37b268c18bbc6acd762647221012005746f370a"
+}

--- a/.sqlx/query-ceaab8de6a88d34dbeee8fa476ad20a07efbceac919b92db522c173500897bf7.json
+++ b/.sqlx/query-ceaab8de6a88d34dbeee8fa476ad20a07efbceac919b92db522c173500897bf7.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO transactions (id, payment_intent_id, session_id, amount, currency, status, created_at, updated_at)\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Int8",
+        "Varchar",
+        "Varchar",
+        "Timestamp",
+        "Timestamp"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ceaab8de6a88d34dbeee8fa476ad20a07efbceac919b92db522c173500897bf7"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stripe"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ddaa6999d246ba2c6c84d830a1ba0cd16c9234d58701988b3869f0e5bd732d"
+dependencies = [
+ "chrono",
+ "futures-util",
+ "hex",
+ "hmac",
+ "http-types",
+ "hyper 0.14.32",
+ "hyper-tls 0.5.0",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_qs 0.10.1",
+ "sha2",
+ "smart-default",
+ "smol_str",
+ "thiserror 1.0.69",
+ "tokio",
+ "uuid 0.8.2",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,7 +103,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -124,10 +160,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -155,8 +191,8 @@ checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -178,8 +214,8 @@ dependencies = [
  "cookie",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -187,6 +223,12 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -428,7 +470,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -451,7 +493,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -513,6 +555,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -520,6 +568,15 @@ dependencies = [
  "concurrent-queue",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -555,6 +612,12 @@ dependencies = [
  "futures-sink",
  "spin",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -643,6 +706,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +757,7 @@ checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -688,13 +778,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -732,6 +833,25 @@ dependencies = [
  "smallvec",
  "spinning_top",
  "web-time",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -812,6 +932,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -822,12 +953,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -838,9 +980,30 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "base64 0.13.1",
+ "futures-lite",
+ "http 0.2.12",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs 0.8.5",
+ "serde_urlencoded",
+ "url",
 ]
 
 [[package]]
@@ -857,6 +1020,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -865,8 +1052,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -879,13 +1066,26 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -899,19 +1099,19 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -1056,6 +1256,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,7 +1319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c76e1c7d7df3e34443b3621b459b066a7b79644f059fc8b2db7070c825fd417e"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "getrandom 0.2.16",
  "js-sys",
  "serde",
@@ -1223,7 +1438,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1284,7 +1499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -1294,6 +1509,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "argon2",
+ "async-stripe",
  "async-trait",
  "axum",
  "axum-extra",
@@ -1308,7 +1524,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "thiserror",
+ "thiserror 2.0.17",
  "time",
  "tokio",
  "tower",
@@ -1318,7 +1534,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "utoipa-swagger-ui",
- "uuid",
+ "uuid 1.19.0",
 ]
 
 [[package]]
@@ -1434,7 +1650,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1604,7 +1820,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -1623,6 +1839,19 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
 
 [[package]]
 name = "rand"
@@ -1647,6 +1876,16 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
@@ -1667,6 +1906,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -1681,6 +1929,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1745,14 +2002,14 @@ version = "0.12.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-tls",
+ "hyper 1.8.1",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
  "log",
@@ -1789,7 +2046,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1846,7 +2103,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn",
+ "syn 2.0.111",
  "walkdir",
 ]
 
@@ -2003,7 +2260,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2028,6 +2285,28 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cac3f1e2ca2fe333923a1ae72caca910b98ed0630bb35ef6f8c8517d6e81afa"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2120,6 +2399,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "smart-default"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2176,13 +2485,13 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -2199,12 +2508,12 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tracing",
  "url",
- "uuid",
+ "uuid 1.19.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -2218,7 +2527,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2241,7 +2550,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.111",
  "tokio",
  "url",
 ]
@@ -2253,7 +2562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "byteorder",
  "bytes",
@@ -2284,9 +2593,9 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.17",
  "tracing",
- "uuid",
+ "uuid 1.19.0",
  "whoami",
 ]
 
@@ -2297,7 +2606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "byteorder",
  "chrono",
@@ -2323,9 +2632,9 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.17",
  "tracing",
- "uuid",
+ "uuid 1.19.0",
  "whoami",
 ]
 
@@ -2349,10 +2658,10 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.17",
  "tracing",
  "url",
- "uuid",
+ "uuid 1.19.0",
 ]
 
 [[package]]
@@ -2377,6 +2686,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2406,7 +2726,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2415,7 +2735,7 @@ version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "fastrand",
+ "fastrand 2.3.0",
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
@@ -2424,11 +2744,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.17",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2439,7 +2779,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2519,7 +2859,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2532,7 +2872,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2552,6 +2892,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -2581,8 +2934,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -2623,7 +2976,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2787,8 +3140,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
- "uuid",
+ "syn 2.0.111",
+ "uuid 1.19.0",
 ]
 
 [[package]]
@@ -2798,7 +3151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
  "axum",
- "base64",
+ "base64 0.22.1",
  "mime_guess",
  "regex",
  "rust-embed",
@@ -2807,6 +3160,15 @@ dependencies = [
  "url",
  "utoipa",
  "zip",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2840,6 +3202,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,6 +3225,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -2924,7 +3298,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
@@ -3037,7 +3411,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3048,7 +3422,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3328,7 +3702,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -3349,7 +3723,7 @@ checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3369,7 +3743,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -3409,7 +3783,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ jsonwebtoken = { version = "10.2.0", default-features = false, features = [
 rand = "0.9.2"
 hex = "0.4.3"
 resend-rs = "0.19.0"
+async-stripe = { version = "0.38.0", features = ["runtime-tokio-hyper"] }
 utoipa = { version = "5.4.0", features = [
     "axum_extras",
     "chrono",

--- a/migrations/20260209094300_create_transactions_table.sql
+++ b/migrations/20260209094300_create_transactions_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE transactions (
+    id UUID PRIMARY KEY,
+    payment_intent_id TEXT,
+    session_id TEXT NOT NULL,
+    amount BIGINT,
+    currency VARCHAR(3),
+    status VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/adapters/http/app_error_impl.rs
+++ b/src/adapters/http/app_error_impl.rs
@@ -22,6 +22,8 @@ impl IntoResponse for AppError {
             AppError::Internal(_) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, "Internal error").into_response()
             }
+            AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg).into_response(),
+            AppError::ExternalServiceError(msg) => (StatusCode::BAD_GATEWAY, msg).into_response(),
             AppError::Unauthorized(_) => (StatusCode::UNAUTHORIZED, "Unauthorized").into_response(),
         }
     }

--- a/src/adapters/http/app_state.rs
+++ b/src/adapters/http/app_state.rs
@@ -5,7 +5,10 @@ use axum::extract::FromRef;
 use crate::{
     infra::config::AppConfig,
     use_cases::{
-        blog_post::BlogPostUseCases, patient::PatientUseCases, professional::ProfessionalUseCases,
+        blog_post::BlogPostUseCases,
+        patient::PatientUseCases,
+        payment::PaymentUseCases,
+        professional::ProfessionalUseCases,
         professional_language::ProfessionalLanguageUseCases,
         professional_specialization::ProfessionalSpecializationUseCases, session::SessionUseCases,
         session_type::SessionTypeUseCases, user::UserUseCases, user_token::UserTokenUseCases,
@@ -24,6 +27,7 @@ pub struct AppState {
     pub professional_languages_use_cases: Arc<ProfessionalLanguageUseCases>,
     pub professional_specializations_use_cases: Arc<ProfessionalSpecializationUseCases>,
     pub blog_post_use_cases: Arc<BlogPostUseCases>,
+    pub payment_use_cases: Arc<PaymentUseCases>,
 }
 
 impl FromRef<AppState> for Arc<UserUseCases> {
@@ -74,8 +78,16 @@ impl FromRef<AppState> for Arc<ProfessionalSpecializationUseCases> {
     }
 }
 
+
 impl FromRef<AppState> for Arc<BlogPostUseCases> {
     fn from_ref(app_state: &AppState) -> Self {
         app_state.blog_post_use_cases.clone()
     }
 }
+
+impl FromRef<AppState> for Arc<PaymentUseCases> {
+    fn from_ref(app_state: &AppState) -> Self {
+        app_state.payment_use_cases.clone()
+    }
+}
+

--- a/src/adapters/http/routes/checkout.rs
+++ b/src/adapters/http/routes/checkout.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+
+use axum::{extract::{State, Json}, http::StatusCode, response::IntoResponse};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    app_error::AppResult,
+    application::use_cases::payment::PaymentUseCases,
+};
+
+#[derive(Deserialize)]
+pub struct CreateCheckoutSessionRequest {
+    pub amount: i64,
+    pub currency: String,
+    pub success_url: String,
+    pub cancel_url: String,
+}
+
+#[derive(Serialize)]
+pub struct CreateCheckoutSessionResponse {
+    pub client_secret: String,
+}
+
+pub async fn create_checkout_session(
+    State(payment_use_cases): State<Arc<PaymentUseCases>>,
+    Json(payload): Json<CreateCheckoutSessionRequest>,
+) -> AppResult<impl IntoResponse> {
+    let client_secret = payment_use_cases.create_checkout_session(
+        payload.amount,
+        payload.currency,
+        payload.success_url,
+        payload.cancel_url,
+    ).await?;
+
+    Ok((StatusCode::OK, Json(CreateCheckoutSessionResponse { client_secret })))
+}

--- a/src/adapters/http/routes/mod.rs
+++ b/src/adapters/http/routes/mod.rs
@@ -7,6 +7,7 @@ pub mod session;
 pub mod session_type;
 pub mod user;
 pub mod user_token;
+pub mod checkout;
 
 use std::sync::Arc;
 
@@ -16,7 +17,8 @@ use crate::{
     entities::user::Role,
     use_cases::user::UserJwtService,
 };
-use axum::{Extension, Router, extract::Request, middleware::Next, response::Response};
+use axum::{Extension, Router, extract::Request, middleware::Next, response::Response, routing::post};
+use checkout::create_checkout_session;
 
 /// Trait that a Payload should implement in order to be validated (TODO: Can I enforce this)
 trait Validateable {
@@ -132,7 +134,8 @@ pub fn router() -> Router<AppState> {
         .nest("/user", user::router())
         .nest("/user_token", user_token::router())
         .nest("/patient", patient::router())
-        .nest("/session_type", session_type::router())
+        .nest("/session-type", session_type::router())
+        .nest("/checkout", Router::new().route("/session", post(create_checkout_session)))
         .nest("/session", session::router())
         .nest("/professional", professional::router())
         .nest("/professional_language", professional_language::router())

--- a/src/adapters/persistence/mod.rs
+++ b/src/adapters/persistence/mod.rs
@@ -10,6 +10,7 @@ pub mod session;
 pub mod session_type;
 pub mod user;
 pub mod user_token;
+pub mod transaction;
 
 #[derive(Clone)]
 pub struct PostgresPersistence {

--- a/src/adapters/persistence/transaction.rs
+++ b/src/adapters/persistence/transaction.rs
@@ -1,0 +1,93 @@
+use async_trait::async_trait;
+use sqlx::query;
+
+
+use crate::{
+
+    app_error::{AppError, AppResult},
+    application::use_cases::payment::TransactionPersistence,
+    domain::entities::transaction::{Transaction, TransactionStatus},
+};
+
+use super::PostgresPersistence;
+
+#[async_trait]
+impl TransactionPersistence for PostgresPersistence {
+    async fn create(&self, transaction: &Transaction) -> AppResult<Transaction> {
+        query!(
+            r#"
+            INSERT INTO transactions (id, payment_intent_id, session_id, amount, currency, status, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            "#,
+            transaction.id,
+            transaction.payment_intent_id,
+            transaction.session_id,
+            transaction.amount,
+            transaction.currency,
+            transaction.status.to_string(),
+            transaction.created_at.naive_utc(),
+            transaction.updated_at.naive_utc()
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to create transaction: {:?}", e);
+            AppError::Database(e)
+        })?;
+
+        Ok(transaction.clone())
+    }
+
+    async fn update(&self, transaction: &Transaction) -> AppResult<Transaction> {
+        query!(
+            r#"
+            UPDATE transactions
+            SET payment_intent_id = $1, status = $2, updated_at = $3
+            WHERE id = $4
+            "#,
+            transaction.payment_intent_id,
+            transaction.status.to_string(),
+            transaction.updated_at.naive_utc(),
+            transaction.id
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to update transaction: {:?}", e);
+            AppError::Database(e)
+        })?;
+
+        Ok(transaction.clone())
+    }
+
+    async fn get_by_session_id(&self, session_id: &str) -> AppResult<Transaction> {
+        let rec = query!(
+            r#"
+            SELECT id, payment_intent_id, session_id, amount, currency, status, created_at, updated_at
+            FROM transactions
+            WHERE session_id = $1
+            "#,
+            session_id
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to fetch transaction: {:?}", e);
+            AppError::Database(e)
+        })?;
+
+        match rec {
+            Some(row) => Ok(Transaction {
+                id: row.id,
+                payment_intent_id: row.payment_intent_id,
+                session_id: row.session_id,
+                amount: row.amount,
+                currency: row.currency,
+                status: TransactionStatus::from(row.status),
+                created_at: row.created_at.expect("created_at cannot be null").and_utc(),
+                updated_at: row.updated_at.expect("updated_at cannot be null").and_utc(),
+            }),
+            None => Err(AppError::NotFound(format!("Transaction with session_id {} not found", session_id))),
+        }
+    }
+}

--- a/src/application/app_error.rs
+++ b/src/application/app_error.rs
@@ -16,6 +16,12 @@ pub enum AppError {
 
     #[error("Internal error: {0}")]
     Internal(String),
+
+    #[error("Not Found: {0}")]
+    NotFound(String),
+
+    #[error("External Service Error: {0}")]
+    ExternalServiceError(String),
 }
 
 pub type AppResult<T> = Result<T, AppError>;

--- a/src/application/use_cases/mod.rs
+++ b/src/application/use_cases/mod.rs
@@ -8,3 +8,4 @@ pub mod session;
 pub mod session_type;
 pub mod user;
 pub mod user_token;
+pub mod payment;

--- a/src/application/use_cases/payment.rs
+++ b/src/application/use_cases/payment.rs
@@ -1,0 +1,82 @@
+use async_trait::async_trait;
+
+use std::sync::Arc;
+use tracing::{info, instrument, error};
+
+use crate::{
+    app_error::AppResult,
+    domain::entities::transaction::Transaction,
+};
+
+#[async_trait]
+pub trait TransactionPersistence: Send + Sync {
+    async fn create(&self, transaction: &Transaction) -> AppResult<Transaction>;
+    async fn update(&self, transaction: &Transaction) -> AppResult<Transaction>;
+    async fn get_by_session_id(&self, session_id: &str) -> AppResult<Transaction>;
+}
+
+#[async_trait]
+pub trait PaymentGateway: Send + Sync {
+    async fn create_checkout_session(
+        &self,
+        amount: i64,
+        currency: &str,
+        success_url: &str,
+        cancel_url: &str,
+        metadata: Option<std::collections::HashMap<String, String>>,
+    ) -> AppResult<(String, String)>; // (client_secret, session_id)
+}
+
+#[derive(Clone)]
+pub struct PaymentUseCases {
+    transaction_persistence: Arc<dyn TransactionPersistence>,
+    payment_gateway: Arc<dyn PaymentGateway>,
+}
+
+impl PaymentUseCases {
+    pub fn new(
+        transaction_persistence: Arc<dyn TransactionPersistence>,
+        payment_gateway: Arc<dyn PaymentGateway>,
+    ) -> Self {
+        Self {
+            transaction_persistence,
+            payment_gateway,
+        }
+    }
+
+    #[instrument(skip(self))]
+    pub async fn create_checkout_session(
+        &self,
+        amount: i64, // Amount in cents
+        currency: String,
+        success_url: String,
+        cancel_url: String,
+    ) -> AppResult<String> {
+        info!("Initiating checkout session creation...");
+
+        // 1. Create Stripe Session
+        let (client_secret, session_id) = self.payment_gateway.create_checkout_session(
+            amount,
+            &currency,
+            &success_url,
+            &cancel_url,
+            None, // Metadata
+        ).await.map_err(|e| {
+            error!("Failed to create stripe session: {:?}", e);
+            e
+        })?;
+
+        // 2. Create Transaction
+        let transaction = Transaction::new(session_id.clone(), Some(amount), Some(currency.clone()));
+
+        // 3. Persist Transaction
+        self.transaction_persistence.create(&transaction).await.map_err(|e| {
+             error!("Failed to persist transaction: {:?}", e);
+             e
+        })?;
+
+        info!("Checkout session created successfully. Transaction ID: {}", transaction.id);
+
+        Ok(client_secret)
+    }
+}

--- a/src/domain/entities/mod.rs
+++ b/src/domain/entities/mod.rs
@@ -1,3 +1,4 @@
+pub mod transaction;
 pub mod blog_post;
 pub mod email;
 pub mod gender;

--- a/src/domain/entities/transaction.rs
+++ b/src/domain/entities/transaction.rs
@@ -1,0 +1,71 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TransactionStatus {
+    Pending,
+    Completed,
+    Failed,
+    Expired,
+}
+
+impl ToString for TransactionStatus {
+    fn to_string(&self) -> String {
+        match self {
+            TransactionStatus::Pending => "pending".to_string(),
+            TransactionStatus::Completed => "completed".to_string(),
+            TransactionStatus::Failed => "failed".to_string(),
+            TransactionStatus::Expired => "expired".to_string(),
+        }
+    }
+}
+
+impl From<String> for TransactionStatus {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "completed" => TransactionStatus::Completed,
+            "failed" => TransactionStatus::Failed,
+            "expired" => TransactionStatus::Expired,
+            _ => TransactionStatus::Pending,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Transaction {
+    pub id: Uuid,
+    pub payment_intent_id: Option<String>,
+    pub session_id: String,
+    pub amount: Option<i64>,
+    pub currency: Option<String>,
+    pub status: TransactionStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Transaction {
+    pub fn new(session_id: String, amount: Option<i64>, currency: Option<String>) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            payment_intent_id: None,
+            session_id,
+            amount,
+            currency,
+            status: TransactionStatus::Pending,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    pub fn complete(&mut self, payment_intent_id: String) {
+        self.status = TransactionStatus::Completed;
+        self.payment_intent_id = Some(payment_intent_id);
+        self.updated_at = Utc::now();
+    }
+
+    pub fn fail(&mut self) {
+        self.status = TransactionStatus::Failed;
+        self.updated_at = Utc::now();
+    }
+}

--- a/src/infra/config.rs
+++ b/src/infra/config.rs
@@ -5,6 +5,7 @@ pub struct AppConfig {
     pub resend_key: String,
     pub resend_from_email: String,
     pub base_frontend_url: String,
+    pub stripe_secret_key: String,
     //pub access_token_ttl: Duration,
     //pub refresh_token_ttl: Duration,
 }
@@ -21,6 +22,9 @@ impl AppConfig {
         let base_frontend_url =
             env::var("BASE_FRONTEND_URL").expect("BASE_FRONTEND_URL must be set");
 
+        let stripe_secret_key =
+            env::var("STRIPE_SECRET_KEY").expect("STRIPE_SECRET_KEY must be set");
+
         // let refresh_token_ttl_days: i64 = env::var("REFRESH_TOKEN_TTL_DAYS")
         //     .unwrap_or("30".to_string())
         //     .parse()
@@ -36,6 +40,7 @@ impl AppConfig {
             resend_key,
             resend_from_email,
             base_frontend_url,
+            stripe_secret_key,
             //access_token_ttl: Duration::seconds(access_token_ttl_secs),
             //refresh_token_ttl: Duration::days(refresh_token_ttl_days),
         }

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -14,6 +14,9 @@ pub mod app;
 pub mod config;
 pub mod db;
 pub mod setup;
+pub mod payment;
+
+use self::payment::stripe_gateway::StripeGateway;
 
 pub async fn postgres_persistence() -> anyhow::Result<PostgresPersistence> {
     let pool = init_db().await?;
@@ -32,4 +35,8 @@ pub fn jwt_service(config: Arc<AppConfig>) -> JwtService {
 
 pub fn email_service(config: Arc<AppConfig>) -> EmailService {
     EmailService::new(config)
+}
+
+pub fn stripe_gateway(config: Arc<AppConfig>) -> StripeGateway {
+    StripeGateway::new(config)
 }

--- a/src/infra/payment/mod.rs
+++ b/src/infra/payment/mod.rs
@@ -1,0 +1,1 @@
+pub mod stripe_gateway;

--- a/src/infra/payment/stripe_gateway.rs
+++ b/src/infra/payment/stripe_gateway.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use stripe::CheckoutSession;
 use stripe::Client;
 use async_trait::async_trait;
 use tracing::error;
@@ -84,4 +85,3 @@ impl PaymentGateway for StripeGateway {
     }
 }
 
-use stripe::CheckoutSession;

--- a/src/infra/payment/stripe_gateway.rs
+++ b/src/infra/payment/stripe_gateway.rs
@@ -1,0 +1,87 @@
+use std::sync::Arc;
+
+use stripe::Client;
+use async_trait::async_trait;
+use tracing::error;
+
+use crate::{
+    app_error::{AppError, AppResult},
+    application::use_cases::payment::PaymentGateway,
+    infra::config::AppConfig,
+};
+
+#[derive(Clone)]
+pub struct StripeGateway {
+    client: Client,
+}
+
+impl StripeGateway {
+    pub fn new(config: Arc<AppConfig>) -> Self {
+        let client = Client::new(config.stripe_secret_key.clone());
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl PaymentGateway for StripeGateway {
+    async fn create_checkout_session(
+        &self,
+        amount: i64,
+        currency: &str,
+        success_url: &str,
+        cancel_url: &str,
+        metadata: Option<std::collections::HashMap<String, String>>,
+    ) -> AppResult<(String, String)> {
+        use stripe::{
+            CheckoutSessionMode, CreateCheckoutSession, CreateCheckoutSessionLineItems,
+            CreateCheckoutSessionLineItemsPriceData,
+            CreateCheckoutSessionLineItemsPriceDataProductData,
+        };
+
+        let mut create_session = CreateCheckoutSession::new();
+        create_session.mode = Some(CheckoutSessionMode::Payment);
+        create_session.ui_mode = Some(stripe::CheckoutSessionUiMode::Embedded);
+        create_session.return_url = Some(success_url);
+        
+        let price_data = CreateCheckoutSessionLineItemsPriceData {
+            currency: currency.parse().unwrap_or(stripe::Currency::EUR), // Default or error handle
+            product_data: Some(CreateCheckoutSessionLineItemsPriceDataProductData {
+                name: "Session Booking".to_string(), // Could be dynamic
+                ..Default::default()
+            }),
+            unit_amount: Some(amount), // Stripe expects amount in cents
+            ..Default::default()
+        };
+
+        let line_item = CreateCheckoutSessionLineItems {
+            quantity: Some(1),
+            price_data: Some(price_data),
+            ..Default::default()
+        };
+
+        create_session.line_items = Some(vec![line_item]);
+
+        if let Some(meta) = metadata {
+             // TODO: [lazaropaul] In "final" app, we would have to map `metadata`
+             // (Transaction info) to Stripe metadata create_session.metadata = ...
+        }
+
+        let session = CheckoutSession::create(&self.client, create_session)
+            .await
+            .map_err(|e| {
+                error!("Stripe create session error: {:?}", e);
+                AppError::ExternalServiceError(format!("Stripe error: {}", e))
+            })?;
+
+        let client_secret = session.client_secret.ok_or_else(|| {
+             error!("Stripe did not return a client_secret");
+             AppError::ExternalServiceError("Stripe did not return a client_secret".into())
+        })?;
+
+        let id = session.id.as_str().to_string();
+
+        Ok((client_secret, id))
+    }
+}
+
+use stripe::CheckoutSession;

--- a/src/infra/setup.rs
+++ b/src/infra/setup.rs
@@ -2,6 +2,7 @@ use crate::{
     adapters::http::app_state::AppState,
     infra::{
         argon2_password_hasher, config::AppConfig, email_service, jwt_service, postgres_persistence,
+        stripe_gateway,
     },
     use_cases::{
         blog_post::BlogPostUseCases,
@@ -13,6 +14,7 @@ use crate::{
         session_type::SessionTypeUseCases,
         user::{UserJwtService, UserUseCases},
         user_token::{UserTokenJwtService, UserTokenUseCases},
+        payment::PaymentUseCases,
     },
 };
 use std::fs::File;
@@ -54,6 +56,9 @@ pub async fn init_app_state() -> anyhow::Result<AppState> {
 
     let blog_post_use_cases = BlogPostUseCases::new(postgres_arc.clone());
 
+    let stripe_gateway = Arc::new(stripe_gateway(Arc::clone(&config)));
+    let payment_use_cases = PaymentUseCases::new(postgres_arc.clone(), stripe_gateway);
+
     Ok(AppState {
         config,
         user_use_cases: Arc::new(user_use_cases),
@@ -65,6 +70,7 @@ pub async fn init_app_state() -> anyhow::Result<AppState> {
         professional_languages_use_cases: Arc::new(professional_languages_use_cases),
         professional_specializations_use_cases: Arc::new(professional_specializations_use_cases),
         blog_post_use_cases: Arc::new(blog_post_use_cases),
+        payment_use_cases: Arc::new(payment_use_cases),
     })
 }
 


### PR DESCRIPTION
This merge request adds the following functionalities:

- **Transaction logging** -> Store and keep track of each session user tries to book, for auditing purposes

- **Stripe session creation** -> Creates a Stripe  session "key" which allows the frontend to render the Stripe checkout with all parameters configured, the workflow is something like this:
  - 1 - Backend (API Layer): create_checkout_session handler receives the request
  - 2 - Backend (Gateway): StripeGateway calls Stripe API
  - 3 - Stripe: Returns a client_secret and a Stripe session_id
  - 4 - Persistence: A new record is inserted into the transactions table with status pending
  - 5 - Response: Backend returns the client_secret to the frontend